### PR TITLE
Versioning Prettier.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,8 +25,8 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: 18
+      - run: npm ci
       - name: Run linters
         uses: wearerequired/lint-action@v2
         with:
           prettier: true
-          prettier_command_prefix: npx

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "copyfiles": "^2.4.1",
         "glob": "^10.3.1",
         "jest": "^29.5.0",
+        "prettier": "^2.8.8",
         "semver": "^7.5.3",
         "typescript": "^5.1.6"
       }
@@ -3395,6 +3396,21 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "2.8.8",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz",
+      "integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==",
+      "dev": true,
+      "bin": {
+        "prettier": "bin-prettier.js"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "node_modules/pretty-format": {
@@ -6864,6 +6880,12 @@
       "requires": {
         "find-up": "^4.0.0"
       }
+    },
+    "prettier": {
+      "version": "2.8.8",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz",
+      "integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==",
+      "dev": true
     },
     "pretty-format": {
       "version": "29.5.0",

--- a/package.json
+++ b/package.json
@@ -28,8 +28,8 @@
   "scripts": {
     "prebuild": "rm -rf lib/*",
     "build": "tsc",
-    "fmt": "npx prettier --write .",
-    "lint": "npx prettier --check .",
+    "fmt": "prettier --write .",
+    "lint": "prettier --check .",
     "pretest": "npm run build",
     "test": "jest"
   },
@@ -38,6 +38,7 @@
     "copyfiles": "^2.4.1",
     "glob": "^10.3.1",
     "jest": "^29.5.0",
+    "prettier": "^2.8.8",
     "semver": "^7.5.3",
     "typescript": "^5.1.6"
   },


### PR DESCRIPTION
Prettierのv3が出たのでnpxだと実行時のキャッシュ次第で実行バージョンがズレるので、バージョン固定する。
https://prettier.io/blog/2023/07/05/3.0.0.html

v3系にしようとしたが、Prettierの公式拡張がv3系を読み込んでくれず、何故か常にビルトインのv2を使うという別の問題が出たので、一旦v2で固定する。
v3に急いで切り替える理由はないし、Prettierの公式拡張のリポジトリでは本体バージョン更新に伴う混乱で別途不具合対応が進んでいるようなので、それを待つ。